### PR TITLE
Fixes delegate name bug

### DIFF
--- a/apps/web/src/lib/stores/signer.ts
+++ b/apps/web/src/lib/stores/signer.ts
@@ -37,9 +37,12 @@ async function getDelegatedSignerName(list: NDKList) {
         await $user?.fetchProfile();
     }
 
-    if ($user?.profile?.name) {
-        name = $user.profile.displayName + `'s `;
-    }
+    name = `${
+        $user?.profile?.displayName ??
+        $user?.profile?.name ??
+        $user?.profile?.nip05 ??
+        `${$user?.npub.slice(0, 9)}...`
+      }'s `;
 
     return name + list.name;
 }

--- a/mobile/src/lib/stores/signer.ts
+++ b/mobile/src/lib/stores/signer.ts
@@ -37,9 +37,12 @@ async function getDelegatedSignerName(list: NDKList) {
         await $user?.fetchProfile();
     }
 
-    if ($user?.profile?.name) {
-        name = $user.profile.displayName + `'s `;
-    }
+    name = `${
+        $user?.profile?.displayName ??
+        $user?.profile?.name ??
+        $user?.profile?.nip05 ??
+        `${$user?.npub.slice(0, 9)}...`
+      }'s `;
 
     return name + list.name;
 }


### PR DESCRIPTION
When creating a delegate to publish kind 1's for a list. The delegate's name is determined by checking the user's `name`, but then, appends the user's `displayName`. In the case where a user has a `name` set but no `displayName` set, this results in the delegate being named `undefined's <listName>`.

This PR goes through a cascade to determine the best delegate name based on the metadata on the user's profile.